### PR TITLE
Support the <dimIndex> tag for custom string indices

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -12,6 +12,9 @@ pub struct Field {
     /// Specify the address increment, in Bytes, between two neighboring array members in the address map.
     #[serde(default, deserialize_with = "deserialize_int_opt")]
     pub dim_increment: Option<u32>,
+    /// Define the indices to use, if not numeric.  Comma separated (e.g. `A,B`).
+    #[serde(default)]
+    pub dim_index: Option<String>,
     /// Name string used to identify the field.
     pub name: String,
     /// String describing the details of the register.
@@ -51,6 +54,10 @@ impl Field {
 impl DimGroup for Field {
     fn dim(&self) -> Option<(u32, u32)> {
         self.dim.and_then(|dim| self.dim_increment.map(|dim_increment| (dim, dim_increment)))
+    }
+
+    fn dim_index(&self) -> &Option<String> {
+        &self.dim_index
     }
 
     fn name(&self) -> &String {

--- a/src/peripheral.rs
+++ b/src/peripheral.rs
@@ -28,6 +28,9 @@ pub struct Peripheral {
     /// Specify the address increment, in Bytes, between two neighboring array members in the address map.
     #[serde(default, deserialize_with = "deserialize_int_opt")]
     pub dim_increment: Option<u32>,
+    /// Define the indices to use, if not numeric.  Comma separated (e.g. `A,B`).
+    #[serde(default)]
+    pub dim_index: Option<String>,
     /// The string identifies the peripheral.
     pub name: String,
     /// The string provides an overview of the purpose and functionality of the peripheral.
@@ -308,6 +311,10 @@ impl Peripheral {
 impl DimGroup for Peripheral {
     fn dim(&self) -> Option<(u32, u32)> {
         self.dim.and_then(|dim| self.dim_increment.map(|dim_increment| (dim, dim_increment)))
+    }
+
+    fn dim_index(&self) -> &Option<String> {
+        &self.dim_index
     }
 
     fn name(&self) -> &String {

--- a/src/register.rs
+++ b/src/register.rs
@@ -20,6 +20,9 @@ pub struct Cluster {
     /// Specify the address increment, in Bytes, between two neighboring array members in the address map.
     #[serde(default, deserialize_with = "deserialize_int_opt")]
     pub dim_increment: Option<u32>,
+    /// Define the indices to use, if not numeric.  Comma separated (e.g. `A,B`).
+    #[serde(default)]
+    pub dim_index: Option<String>,
     /// String to identify the cluster.
     pub name: String,
     /// String describing the details of the register cluster.
@@ -44,6 +47,9 @@ pub struct Register {
     /// Specify the address increment, in Bytes, between two neighboring array members in the address map.
     #[serde(default, deserialize_with = "deserialize_int_opt")]
     pub dim_increment: Option<u32>,
+    /// Define the indices to use, if not numeric.  Comma separated (e.g. `A,B`).
+    #[serde(default)]
+    pub dim_index: Option<String>,
     /// String to identify the register.
     pub name: String,
     /// String describing the details of the register.
@@ -202,6 +208,10 @@ impl DimGroup for Cluster {
         self.dim.and_then(|dim| self.dim_increment.map(|dim_increment| (dim, dim_increment)))
     }
 
+    fn dim_index(&self) -> &Option<String> {
+        &self.dim_index
+    }
+
     fn name(&self) -> &String {
         &self.name
     }
@@ -210,6 +220,10 @@ impl DimGroup for Cluster {
 impl DimGroup for Register {
     fn dim(&self) -> Option<(u32, u32)> {
         self.dim.and_then(|dim| self.dim_increment.map(|dim_increment| (dim, dim_increment)))
+    }
+
+    fn dim_index(&self) -> &Option<String> {
+        &self.dim_index
     }
 
     fn name(&self) -> &String {


### PR DESCRIPTION
This is used by some NXP SVDs that I've started to map