### PR TITLE
Support different casing of read-writeonce and read-writeOnce

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ pub enum Access {
     /// Read access is always permitted. Only the first write access after a
     /// reset will have an effect on the content. Other write operations have an
     /// undefined result.
+    #[serde(alias = "read-writeonce")]
+    #[serde(alias = "read-writeOnce")]
     ReadWriteonce,
 }
 


### PR DESCRIPTION
In reality, I believe the SVD attribute parsing needs to be case
insensitive everywhere, but that might be a more intrusive change...